### PR TITLE
Fixed import error for navbar style and pkce 

### DIFF
--- a/SMART on Epic/README.md
+++ b/SMART on Epic/README.md
@@ -1,8 +1,17 @@
-# React + Vite
+# EHR Data Demo Application
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
-Currently, two official plugins are available:
+## Dev Guide
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+The Client ID in config/config.js must be set to the project value.
+
+### Initial Setup
+```bash
+npm install
+```
+
+### Local Network Testing
+```bash
+npm run dev
+```

--- a/SMART on Epic/package.json
+++ b/SMART on Epic/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/SMART on Epic/src/api/fhirQueryFunctions.js
+++ b/SMART on Epic/src/api/fhirQueryFunctions.js
@@ -104,26 +104,3 @@ export async function getPatientMedicalHistory() {
     }
 }
 
-// https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/STU3/Condition?patient=e63wRTbPfr1p8UW81d8Seiw3
-//'https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4'
-// Get medication info about Patients from FHIR
-export async function getSTU3Condition() {
-    const access_token = localStorage.getItem("access_token");
-    const patient_id = localStorage.getItem("patient_id");
-
-    try {
-        const res = await axios.get(`https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/STU3/Condition`, {
-            params: { 
-                subject: patient_id
-            },
-
-            headers: { 
-                "Authorization": `Bearer ${access_token}` 
-            }
-        });
-	console.log(res.data);
-        return res.data;
-    } catch (error) {
-        console.error("Error fetching STU3 Condition details:", error.response ? error.response.data : error.message);
-    }
-}

--- a/SMART on Epic/src/api/fhirQueryFunctions.js
+++ b/SMART on Epic/src/api/fhirQueryFunctions.js
@@ -81,3 +81,49 @@ export async function getPatientVitals() {
         console.error("Error fetching vitals details:", error.response ? error.response.data : error.message);
     }
 }
+
+// Get vitals info about Patients from FHIR
+export async function getPatientMedicalHistory() {
+    const access_token = localStorage.getItem("access_token");
+    const patient_id = localStorage.getItem("patient_id");
+
+    try {
+        const res = await axios.get(`${CONFIG.FHIR_BASE_URL}/Condition`, {
+            params: { 
+                subject: patient_id,
+                category: "medical-history",
+            },
+
+            headers: { 
+                "Authorization": `Bearer ${access_token}` 
+            }
+        });
+        return res.data;
+    } catch (error) {
+        console.error("Error fetching vitals details:", error.response ? error.response.data : error.message);
+    }
+}
+
+// https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/STU3/Condition?patient=e63wRTbPfr1p8UW81d8Seiw3
+//'https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4'
+// Get medication info about Patients from FHIR
+export async function getSTU3Condition() {
+    const access_token = localStorage.getItem("access_token");
+    const patient_id = localStorage.getItem("patient_id");
+
+    try {
+        const res = await axios.get(`https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/STU3/Condition`, {
+            params: { 
+                subject: patient_id
+            },
+
+            headers: { 
+                "Authorization": `Bearer ${access_token}` 
+            }
+        });
+	console.log(res.data);
+        return res.data;
+    } catch (error) {
+        console.error("Error fetching STU3 Condition details:", error.response ? error.response.data : error.message);
+    }
+}

--- a/SMART on Epic/src/auth/getToken.js
+++ b/SMART on Epic/src/auth/getToken.js
@@ -28,7 +28,8 @@ export async function getToken(){
             client_id: config.CLIENT_ID,
             code_verifier: localStorage.getItem("code_verifier"),
         });
-
+	console.log("url body");
+	console.log(body);
         // Make the token request
         const res = await axios.post(token_endpoint, body, {
             headers: {

--- a/SMART on Epic/src/components/NavBar.jsx
+++ b/SMART on Epic/src/components/NavBar.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import "../styles/Navbar.css";
+import "../styles/NavBar.css";
 
 function Navbar() {
     return (

--- a/SMART on Epic/src/config/config.js
+++ b/SMART on Epic/src/config/config.js
@@ -1,4 +1,5 @@
 // List of all endpoints
+//MEDLINKS_CLIENT_ID: 'a56411ee-67d8-43be-a181-1ef625da3c64',
 export const CONFIG = {
     ISSUER: '',
     ACCESS_TOKEN: '',
@@ -6,7 +7,7 @@ export const CONFIG = {
     CODE_VERIFIER: '',
     AUTHORIZATION_ENDPOINT: '',
     TOKEN_ENDPOINT: '',
-    CLIENT_ID: 'a56411ee-67d8-43be-a181-1ef625da3c64',
+    CLIENT_ID: 'e9f9d011-0ef4-4d58-9851-bca45d30c70c',
     REDIRECT_URI: 'http://localhost:5173/callback',
     FHIR_BASE_URL: 'https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4'
 };

--- a/SMART on Epic/src/pages/CallBack.jsx
+++ b/SMART on Epic/src/pages/CallBack.jsx
@@ -18,7 +18,6 @@ function CallBack() {
                     localStorage.setItem("patient_id", tokenData.patient);
                     // Set the access_token in the config
                     setToken(tokenData.access_token)
-
                     navigate("/patient-home"); // Redirect if successful
                 }
             } catch (error) {

--- a/SMART on Epic/src/pages/CallBack.jsx
+++ b/SMART on Epic/src/pages/CallBack.jsx
@@ -17,7 +17,7 @@ function CallBack() {
                     localStorage.setItem("access_token", tokenData.access_token);
                     localStorage.setItem("patient_id", tokenData.patient);
                     // Set the access_token in the config
-                    setToken(tokenData.access_token)
+                    setToken(tokenData.access_token);
                     navigate("/patient-home"); // Redirect if successful
                 }
             } catch (error) {

--- a/SMART on Epic/src/pages/Home.jsx
+++ b/SMART on Epic/src/pages/Home.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import getWellKnown from '../auth/wellKnown';
 import { getVariables } from '../config/config';
-import { getChallenge } from '../auth/pcke';
+import { getChallenge } from '../auth/pkce';
 import { setChallenge } from "../config/config";
 import { authURL } from '../auth/authorization';
 import SignIn from '../components/SignInButton';

--- a/SMART on Epic/src/pages/PatientHome.jsx
+++ b/SMART on Epic/src/pages/PatientHome.jsx
@@ -1,6 +1,6 @@
 // PatientPage.jsx
 import { useState, useEffect } from "react";
-import { getPatientDetails } from "../api/fhirQueryFunctions";
+import { getPatientDetails, getSTU3Condition } from "../api/fhirQueryFunctions";
 import Navbar from "../components/NavBar";
 import PatientDetailsList from "../components/PatientDetails";
 
@@ -10,6 +10,7 @@ function PatientPage() {
 
     useEffect(() => {
         const fetchDetails = async () => {
+	    const condition = await getSTU3Condition();
             const patient = await getPatientDetails();
             setDetails(patient);
             

--- a/SMART on Epic/src/pages/PatientHome.jsx
+++ b/SMART on Epic/src/pages/PatientHome.jsx
@@ -1,6 +1,6 @@
 // PatientPage.jsx
 import { useState, useEffect } from "react";
-import { getPatientDetails, getSTU3Condition } from "../api/fhirQueryFunctions";
+import { getPatientDetails } from "../api/fhirQueryFunctions";
 import Navbar from "../components/NavBar";
 import PatientDetailsList from "../components/PatientDetails";
 
@@ -10,7 +10,6 @@ function PatientPage() {
 
     useEffect(() => {
         const fetchDetails = async () => {
-	    const condition = await getSTU3Condition();
             const patient = await getPatientDetails();
             setDetails(patient);
             


### PR DESCRIPTION
The React NavBar component in SMART on EPIC was importing Navbar.css rather than NavBar.css

The React Native page Home.jsx was importing pcke rather than pkce. Recall that the acronym is for Public Key Code Exchange as defined in RFC 7636

These fixes allow for the SMART sign in flow to offer the epic login portal and now the uri redirect is completed.

However, I notice error in the console logs and the results just return the 'loading' text. More work is to be done in order to fix the code as it exists publicly. 